### PR TITLE
0.2.0 Migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ application {
 }
 
 // Semantic versioning
-version = '0.1.0'
+version = '0.2.0'
 
 // Dependencies
 repositories {

--- a/src/main/java/io/github/moonslanding/tlm/TLMGame.java
+++ b/src/main/java/io/github/moonslanding/tlm/TLMGame.java
@@ -1,5 +1,6 @@
 package io.github.moonslanding.tlm;
 
+import io.github.moonslanding.tlm.camera.FollowedGameView;
 import io.github.moonslanding.tlm.engine.*;
 
 import javax.swing.*;
@@ -9,13 +10,13 @@ import java.awt.event.KeyEvent;
 public class TLMGame {
 
     private static final Sprite playerShipSprite = SpriteCache.loadSprite("player_ship");
+    private static GameWorld world = new GameWorld(10000, 10000);
+    private static Game game = new Game(world);
+    private static GameView gui;
+    private static JFrame window = new JFrame();
 
     public static void main(String[] args) {
-        Game game = new Game();
-        GameView gui = new GameView(game);
-        JFrame window = new JFrame();
-
-        testSprites(game);
+        gui = new GameView(game);
 
         window.add(gui);
         window.pack();
@@ -26,6 +27,7 @@ public class TLMGame {
         window.setVisible(true);
 
         gui.startDrawThread();
+        testFollow(game);
     }
 
     @Deprecated
@@ -66,6 +68,40 @@ public class TLMGame {
         }, GameScene.KeybindEventType.RELEASED);
 
         game.setCurrentScene(demoScene);
+    }
+
+    private static void testFollow(Game game) {
+        SpritedGameObject player = new SpritedGameObject(
+                world.getWidth() / 2,
+                world.getHeight() / 2,
+                "player_ship"
+        );
+        world.addObject(player);
+        GameScene followScene = new GameScene(game);
+        followScene.registerKeybind(KeyEvent.VK_W, (g) -> {
+            player.move(0, -100);
+        }, GameScene.KeybindEventType.PRESSED);
+        followScene.registerKeybind(KeyEvent.VK_S, (g) -> {
+            player.move(0, 100);
+        }, GameScene.KeybindEventType.PRESSED);
+        followScene.registerKeybind(KeyEvent.VK_A, (g) -> {
+            player.move(-100, 0);
+        }, GameScene.KeybindEventType.PRESSED);
+        followScene.registerKeybind(KeyEvent.VK_D, (g) -> {
+            player.move(100, 0);
+        }, GameScene.KeybindEventType.PRESSED);
+        game.setCurrentScene(followScene);
+
+        changeView(new FollowedGameView(game, player));
+    }
+
+    private static void changeView(GameView view) {
+        gui.stopDrawThread();
+        gui = view;
+        gui.revalidate();
+        window.add(gui);
+        window.pack();
+        gui.startDrawThread();
     }
 
 

--- a/src/main/java/io/github/moonslanding/tlm/TLMGame.java
+++ b/src/main/java/io/github/moonslanding/tlm/TLMGame.java
@@ -6,11 +6,12 @@ import io.github.moonslanding.tlm.engine.*;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyEvent;
+import java.util.Random;
 
 public class TLMGame {
 
     private static final Sprite playerShipSprite = SpriteCache.loadSprite("player_ship");
-    private static GameWorld world = new GameWorld(10000, 10000);
+    private static GameWorld world = new GameWorld(2000,2000 );
     private static Game game = new Game(world);
     private static GameView gui;
     private static JFrame window = new JFrame();
@@ -30,46 +31,6 @@ public class TLMGame {
         testFollow(game);
     }
 
-    @Deprecated
-    private static void testSprites(Game game) {
-        game.getWorld().addObject(
-                new SpritedGameObject(
-                        (game.getWorld().getWidth() / 2) - (playerShipSprite.getWidth() / 2),
-                        (game.getWorld().getHeight() / 2) - (playerShipSprite.getHeight() / 2),
-                        "player_ship")
-        );
-
-        // Tinting Test
-        SpritedGameObject yellowShip = new SpritedGameObject(
-                (game.getWorld().getWidth() / 2) - (playerShipSprite.getWidth() / 2) - 30,
-                (game.getWorld().getHeight() / 2) - (playerShipSprite.getHeight() / 2),
-                "player_ship"
-        );
-        yellowShip.setTint(Color.YELLOW);
-        game.getWorld().addObject(yellowShip);
-
-        SpritedGameObject cyanShip = new SpritedGameObject(
-                (game.getWorld().getWidth() / 2) - (playerShipSprite.getWidth() / 2) + 30,
-                (game.getWorld().getHeight() / 2) - (playerShipSprite.getHeight() / 2),
-                "player_ship"
-        );
-        cyanShip.setTint(Color.CYAN);
-        game.getWorld().addObject(cyanShip);
-
-        // Demo Scene
-        GameScene demoScene = new GameScene(game);
-
-        demoScene.registerKeybind(KeyEvent.VK_W, (e) -> {
-            System.out.println("W Pressed");
-        }, GameScene.KeybindEventType.PRESSED);
-
-        demoScene.registerKeybind(KeyEvent.VK_W, (e) -> {
-            System.out.println("W Released");
-        }, GameScene.KeybindEventType.RELEASED);
-
-        game.setCurrentScene(demoScene);
-    }
-
     private static void testFollow(Game game) {
         SpritedGameObject player = new SpritedGameObject(
                 world.getWidth() / 2,
@@ -77,18 +38,29 @@ public class TLMGame {
                 "player_ship"
         );
         world.addObject(player);
+        player.setTint(Color.CYAN);
+
+        Random rand = new Random();
+        for (int i = 0; i < 100; i++) {
+            world.addObject(new SpritedGameObject(
+                    rand.nextInt(0, world.getWidth()),
+                    rand.nextInt(0, world.getHeight()),
+                    "player_ship"
+            ));
+        }
+
         GameScene followScene = new GameScene(game);
         followScene.registerKeybind(KeyEvent.VK_W, (g) -> {
-            player.move(0, -100);
+            player.move(0, -10);
         }, GameScene.KeybindEventType.PRESSED);
         followScene.registerKeybind(KeyEvent.VK_S, (g) -> {
-            player.move(0, 100);
+            player.move(0, 10);
         }, GameScene.KeybindEventType.PRESSED);
         followScene.registerKeybind(KeyEvent.VK_A, (g) -> {
-            player.move(-100, 0);
+            player.move(-10, 0);
         }, GameScene.KeybindEventType.PRESSED);
         followScene.registerKeybind(KeyEvent.VK_D, (g) -> {
-            player.move(100, 0);
+            player.move(10, 0);
         }, GameScene.KeybindEventType.PRESSED);
         game.setCurrentScene(followScene);
 
@@ -103,7 +75,5 @@ public class TLMGame {
         window.pack();
         gui.startDrawThread();
     }
-
-
 
 }

--- a/src/main/java/io/github/moonslanding/tlm/TLMGame.java
+++ b/src/main/java/io/github/moonslanding/tlm/TLMGame.java
@@ -24,8 +24,11 @@ public class TLMGame {
         window.setResizable(false);
         window.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         window.setVisible(true);
+
+        gui.startDrawThread();
     }
 
+    @Deprecated
     private static void testSprites(Game game) {
         game.getWorld().addObject(
                 new SpritedGameObject(
@@ -51,23 +54,20 @@ public class TLMGame {
         cyanShip.setTint(Color.CYAN);
         game.getWorld().addObject(cyanShip);
 
-
         // Demo Scene
         GameScene demoScene = new GameScene(game);
 
         demoScene.registerKeybind(KeyEvent.VK_W, (e) -> {
             System.out.println("W Pressed");
-        }, "pressed");
+        }, GameScene.KeybindEventType.PRESSED);
 
         demoScene.registerKeybind(KeyEvent.VK_W, (e) -> {
             System.out.println("W Released");
-        }, "released");
-
-
-
+        }, GameScene.KeybindEventType.RELEASED);
 
         game.setCurrentScene(demoScene);
-
     }
+
+
 
 }

--- a/src/main/java/io/github/moonslanding/tlm/camera/FollowedGameView.java
+++ b/src/main/java/io/github/moonslanding/tlm/camera/FollowedGameView.java
@@ -1,38 +1,78 @@
 package io.github.moonslanding.tlm.camera;
 
-import io.github.moonslanding.tlm.engine.Game;
-import io.github.moonslanding.tlm.engine.GameObject;
-import io.github.moonslanding.tlm.engine.GameView;
-import io.github.moonslanding.tlm.engine.GameWorld;
+import io.github.moonslanding.tlm.engine.*;
 
 import java.awt.*;
 
 public class FollowedGameView extends GameView {
 
     private final GameWorld world;
-    private final GameObject pivotObject;
+    private final SpritedGameObject pivotObject;
+    private Point gvThreshold;
 
-    public FollowedGameView(Game game, int width, int height, GameObject pivotObject) {
+    public FollowedGameView(Game game, int width, int height, SpritedGameObject pivotObject) {
         super(game, width, height);
         this.pivotObject = pivotObject;
         if(game.getWorld() == null) {
             throw new NullPointerException("Game doesn't have an initialized GameWorld or is null");
         }
         world = game.getWorld();
+        gvThreshold = getCenterOfCanvas();
     }
 
-    public FollowedGameView(Game game, GameObject pivotObject) {
+    public FollowedGameView(Game game, SpritedGameObject pivotObject) {
         super(game);
         this.pivotObject = pivotObject;
         if(game.getWorld() == null) {
             throw new NullPointerException("Game doesn't have an initialized GameWorld or is null");
         }
         world = game.getWorld();
+        gvThreshold = getCenterOfCanvas();
     }
 
     @Override
     public void renderOnCanvas(Graphics g) {
-        //super.renderOnCanvas(g);
         // TODO: Make the canvas follow the pivotObject and as it gets closer to a wall, lease the object.
+        Graphics2D g2d = (Graphics2D) g.create();
+        g2d.setColor(Color.white);
+        g2d.drawString("" + pivotObject.getX() + "," + pivotObject.getY() + "", 50, 50);
+        renderPivotObject(g);
+        g2d.dispose();
     }
+
+    private void renderPivotObject(Graphics g) {
+        int zoom = 1;
+        Point pivotCoords = new Point(pivotObject.getX(), pivotObject.getY());
+        Graphics2D g2d = (Graphics2D) g.create();
+        WrappedGraphic wg = new WrappedGraphic(g2d, zoom);
+
+        if (pivotCoords.x >= gvThreshold.x
+                && pivotCoords.y >= gvThreshold.y
+                && pivotCoords.x <= world.getWidth() - gvThreshold.x
+                && pivotCoords.y <= world.getHeight() - gvThreshold.y
+        ) {
+            pivotObject.render(wg, gvThreshold.x, gvThreshold.y);
+        } else {
+            // TODO: Calculate x and y for relative position of player rendering.
+            // Note: render should only fire once.
+        }
+
+        // TODO: Make other objects render within FoV.
+        g2d.dispose();
+    }
+
+    private Point getCenterOfCanvas() {
+        return new Point(this.getPreferredSize().width / 2, this.getPreferredSize().height / 2);
+    }
+
+    private class Point {
+        int x;
+        int y;
+
+        public Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
 }

--- a/src/main/java/io/github/moonslanding/tlm/camera/FollowedGameView.java
+++ b/src/main/java/io/github/moonslanding/tlm/camera/FollowedGameView.java
@@ -1,0 +1,38 @@
+package io.github.moonslanding.tlm.camera;
+
+import io.github.moonslanding.tlm.engine.Game;
+import io.github.moonslanding.tlm.engine.GameObject;
+import io.github.moonslanding.tlm.engine.GameView;
+import io.github.moonslanding.tlm.engine.GameWorld;
+
+import java.awt.*;
+
+public class FollowedGameView extends GameView {
+
+    private final GameWorld world;
+    private final GameObject pivotObject;
+
+    public FollowedGameView(Game game, int width, int height, GameObject pivotObject) {
+        super(game, width, height);
+        this.pivotObject = pivotObject;
+        if(game.getWorld() == null) {
+            throw new NullPointerException("Game doesn't have an initialized GameWorld or is null");
+        }
+        world = game.getWorld();
+    }
+
+    public FollowedGameView(Game game, GameObject pivotObject) {
+        super(game);
+        this.pivotObject = pivotObject;
+        if(game.getWorld() == null) {
+            throw new NullPointerException("Game doesn't have an initialized GameWorld or is null");
+        }
+        world = game.getWorld();
+    }
+
+    @Override
+    public void renderOnCanvas(Graphics g) {
+        //super.renderOnCanvas(g);
+        // TODO: Make the canvas follow the pivotObject and as it gets closer to a wall, lease the object.
+    }
+}

--- a/src/main/java/io/github/moonslanding/tlm/camera/FollowedGameView.java
+++ b/src/main/java/io/github/moonslanding/tlm/camera/FollowedGameView.java
@@ -1,6 +1,8 @@
 package io.github.moonslanding.tlm.camera;
 
+import io.github.moonslanding.tlm.TLMGame;
 import io.github.moonslanding.tlm.engine.*;
+import io.github.moonslanding.tlm.engine.interfaces.IRenderable;
 
 import java.awt.*;
 
@@ -34,45 +36,90 @@ public class FollowedGameView extends GameView {
     public void renderOnCanvas(Graphics g) {
         // TODO: Make the canvas follow the pivotObject and as it gets closer to a wall, lease the object.
         Graphics2D g2d = (Graphics2D) g.create();
-        g2d.setColor(Color.white);
-        g2d.drawString("" + pivotObject.getX() + "," + pivotObject.getY() + "", 50, 50);
-        renderPivotObject(g);
+        renderAll(g);
         g2d.dispose();
     }
 
-    private void renderPivotObject(Graphics g) {
+    private void renderAll(Graphics g) {
         int zoom = 1;
         Point pivotCoords = new Point(pivotObject.getX(), pivotObject.getY());
         Graphics2D g2d = (Graphics2D) g.create();
         WrappedGraphic wg = new WrappedGraphic(g2d, zoom);
 
-        if (pivotCoords.x >= gvThreshold.x
-                && pivotCoords.y >= gvThreshold.y
-                && pivotCoords.x <= world.getWidth() - gvThreshold.x
-                && pivotCoords.y <= world.getHeight() - gvThreshold.y
-        ) {
-            pivotObject.render(wg, gvThreshold.x, gvThreshold.y);
+        int x, y;
+        Point viewCenter = new Point(pivotCoords.x, pivotCoords.y);
+
+        boolean withinX = (pivotCoords.x >= gvThreshold.x
+                && pivotCoords.x <= world.getWidth() - gvThreshold.x);
+        boolean withinY = (pivotCoords.y >= gvThreshold.y
+                && pivotCoords.y <= world.getHeight() - gvThreshold.y);
+
+        if (withinX) {
+            x = gvThreshold.x;
         } else {
-            // TODO: Calculate x and y for relative position of player rendering.
-            // Note: render should only fire once.
+            if (pivotCoords.x < gvThreshold.x) {
+                x = (((pivotCoords.x) * gvThreshold.x) / gvThreshold.x);
+                viewCenter.x = minLimitedBoundary(pivotCoords.x, gvThreshold.x, gvThreshold.x);
+            } else {
+                x = (((pivotCoords.x - (world.getWidth() - gvThreshold.x))
+                        * (getWidth() - gvThreshold.x))
+                        / (world.getWidth() - (world.getWidth() - gvThreshold.x))) + gvThreshold.x;
+                viewCenter.x = maxLimitedBoundary(pivotCoords.x, gvThreshold.x, world.getWidth() - gvThreshold.x);
+            }
         }
 
-        // TODO: Make other objects render within FoV.
+        if (withinY) {
+            y = gvThreshold.y;
+        } else {
+            if (pivotCoords.y < gvThreshold.y) {
+                y = (((pivotCoords.y) * gvThreshold.y) / gvThreshold.y);
+                viewCenter.y = minLimitedBoundary(pivotCoords.y, gvThreshold.y, gvThreshold.y);
+            } else {
+                y = (((pivotCoords.y - (world.getHeight() - gvThreshold.y))
+                        * (getHeight() - gvThreshold.y))
+                        / (world.getHeight() - (world.getHeight() - gvThreshold.y))) + gvThreshold.y;
+                viewCenter.y = maxLimitedBoundary(pivotCoords.y, gvThreshold.y, world.getHeight() - gvThreshold.y);
+            }
+        }
+
+        pivotObject.render(wg, x, y);
+        renderObjectsInFoV(g, 50, viewCenter);
         g2d.dispose();
+    }
+
+    private void renderObjectsInFoV(Graphics g, int maxOffset, Point viewCenter) {
+        int zoom = 1;
+        Graphics2D g2d = (Graphics2D) g.create();
+        WrappedGraphic wg = new WrappedGraphic(g2d, zoom);
+
+        world.getObjects().forEach((o) -> {
+            if (o == pivotObject) return;
+            if (o.getX() < viewCenter.x - (gvThreshold.x + maxOffset)
+            || o.getX() > viewCenter.x + (gvThreshold.x + maxOffset)
+            || o.getY() < viewCenter.y - (gvThreshold.y + maxOffset)
+            || o.getY() > viewCenter.y + (gvThreshold.y + maxOffset)) return;
+            if (o instanceof IRenderable) {
+                Point objectCoords = new Point(o.getX(), o.getY());
+                int dx = objectCoords.x - viewCenter.x;
+                int dy = objectCoords.y - viewCenter.y;
+                ((IRenderable) o).render(wg, gvThreshold.x + dx, gvThreshold.y + dy);
+            }
+        });
+        g2d.dispose();
+    }
+
+    private int minLimitedBoundary(int center, int offset, int min) {
+        if (center < offset) return min;
+        return center - offset;
+    }
+
+    private int maxLimitedBoundary(int center, int offset, int max) {
+        if (center > (max - offset)) return max;
+        return center + offset;
     }
 
     private Point getCenterOfCanvas() {
         return new Point(this.getPreferredSize().width / 2, this.getPreferredSize().height / 2);
-    }
-
-    private class Point {
-        int x;
-        int y;
-
-        public Point(int x, int y) {
-            this.x = x;
-            this.y = y;
-        }
     }
 
 }

--- a/src/main/java/io/github/moonslanding/tlm/engine/Game.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/Game.java
@@ -3,7 +3,7 @@ package io.github.moonslanding.tlm.engine;
 public class Game {
 
     private GameWorld world;
-    private GameScene CurrentScene;
+    private GameScene currentScene;
 
     public Game(GameWorld world) {
         this.world = world;
@@ -23,12 +23,12 @@ public class Game {
 
 
     public GameScene getCurrentScene() {
-        return CurrentScene;
+        return currentScene;
     }
 
     public void setCurrentScene(GameScene scene) {
         // do some stuff here
-        this.CurrentScene = scene;
+        this.currentScene = scene;
     }
 
 }

--- a/src/main/java/io/github/moonslanding/tlm/engine/GameScene.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/GameScene.java
@@ -28,7 +28,6 @@ public class GameScene {
     }
 
     public void onKeyPressed(KeyEvent e) {
-        System.out.println(e);
         if (pressListeners.containsKey(e.getKeyCode())) {
             pressListeners.get(e.getKeyCode()).accept(game);
         }

--- a/src/main/java/io/github/moonslanding/tlm/engine/GameScene.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/GameScene.java
@@ -15,23 +15,15 @@ public class GameScene {
         this.game = game;
     }
 
-    public void registerKeybind(int KeyCode, Consumer<Game> consumer, String type) {
-        /**
-         * @Param type the input string whether `pressed` or `released`
-         *
-         *
-         *
-         *
-         */
-switch (type.toLowerCase()) {
-            case "pressed":
-                pressListeners.put(KeyCode, consumer);
-                break;
-            case "released":
-                releaseListeners.put(KeyCode, consumer);
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid type: " + type);
+    public enum KeybindEventType {
+        PRESSED,
+        RELEASED
+    }
+
+    public void registerKeybind(int KeyCode, Consumer<Game> consumer, KeybindEventType eventType) {
+        switch (eventType) {
+            case PRESSED -> pressListeners.put(KeyCode, consumer);
+            case RELEASED -> releaseListeners.put(KeyCode, consumer);
         }
     }
 

--- a/src/main/java/io/github/moonslanding/tlm/engine/GameView.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/GameView.java
@@ -8,13 +8,15 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
 
-public class GameView extends Canvas {
+public class GameView extends Canvas implements Runnable {
 
     private final Game game;
+    private Thread drawThread;
+    private final int FPS = 60;
 
-    public GameView(Game game) {
+    public GameView(Game game, int width, int height) {
         this.game = game;
-        setPreferredSize(new Dimension(game.getWorld().getWidth(), game.getWorld().getHeight()));
+        setPreferredSize(new Dimension(width, height));
         this.addKeyListener(new KeyAdapter(){
             @Override
             public void keyPressed(KeyEvent e) {
@@ -22,9 +24,19 @@ public class GameView extends Canvas {
             }
 
             @Override
-            public void keyReleased(KeyEvent e){
-            game.getCurrentScene().onKeyReleased(e);
-        }});
+            public void keyReleased(KeyEvent e) {
+                game.getCurrentScene().onKeyReleased(e);
+            }
+        });
+    }
+
+    public GameView(Game game) {
+        this(game, 800, 600);
+    }
+
+    public void startDrawThread() {
+        drawThread = new Thread(this);
+        drawThread.start();
     }
 
     @Override
@@ -39,6 +51,24 @@ public class GameView extends Canvas {
                 ((IRenderable) gameObject).render(wrappedGraphic);
             }
         });
+    }
+
+    @Override
+    public void run() {
+        double drawInterval = 1000000000/FPS;
+        double delta = 0;
+        long lastTime = System.nanoTime();
+        long currentTime;
+
+        while(drawThread != null) {
+            currentTime = System.nanoTime();
+            delta += (currentTime - lastTime) / drawInterval;
+            lastTime = currentTime;
+            if (delta >= 1) {
+                repaint();
+                delta--;
+            }
+        }
     }
 
 //    public  void addKeyListener(new KeyAdapter(){

--- a/src/main/java/io/github/moonslanding/tlm/engine/GameView.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/GameView.java
@@ -6,7 +6,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 
 
 public class GameView extends JPanel implements Runnable {
@@ -55,14 +54,14 @@ public class GameView extends JPanel implements Runnable {
     }
 
     public void renderOnCanvas(Graphics g) {
+        Graphics2D graphics = (Graphics2D) g.create();
         game.getWorld().getObjects().forEach(gameObject -> {
             if (gameObject instanceof IRenderable) {
-                Graphics2D graphics = (Graphics2D) g.create();
                 WrappedGraphic wrappedGraphic = new WrappedGraphic(graphics, 3);
                 ((IRenderable) gameObject).render(wrappedGraphic);
-                graphics.dispose();
             }
         });
+        graphics.dispose();
     }
 
     @Override

--- a/src/main/java/io/github/moonslanding/tlm/engine/GameView.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/GameView.java
@@ -2,21 +2,25 @@ package io.github.moonslanding.tlm.engine;
 
 import io.github.moonslanding.tlm.engine.interfaces.IRenderable;
 
+import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
 
-public class GameView extends Canvas implements Runnable {
+public class GameView extends JPanel implements Runnable {
 
     private final Game game;
     private Thread drawThread;
     private final int FPS = 60;
 
     public GameView(Game game, int width, int height) {
+        super(true);
         this.game = game;
         setPreferredSize(new Dimension(width, height));
+        setBackground(Color.black);
+        setFocusable(true);
         this.addKeyListener(new KeyAdapter(){
             @Override
             public void keyPressed(KeyEvent e) {
@@ -39,16 +43,24 @@ public class GameView extends Canvas implements Runnable {
         drawThread.start();
     }
 
+    public void stopDrawThread() {
+        drawThread.interrupt();
+        drawThread = null;
+    }
+
     @Override
-    public void paint(Graphics g) {
-        super.paint(g);
-        g.setColor(Color.BLACK);
-        g.fillRect(0, 0, this.getWidth(), this.getHeight());
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        renderOnCanvas(g);
+    }
+
+    public void renderOnCanvas(Graphics g) {
         game.getWorld().getObjects().forEach(gameObject -> {
             if (gameObject instanceof IRenderable) {
-                Graphics graphics = this.getGraphics();
+                Graphics2D graphics = (Graphics2D) g.create();
                 WrappedGraphic wrappedGraphic = new WrappedGraphic(graphics, 3);
                 ((IRenderable) gameObject).render(wrappedGraphic);
+                graphics.dispose();
             }
         });
     }

--- a/src/main/java/io/github/moonslanding/tlm/engine/GameWorld.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/GameWorld.java
@@ -27,6 +27,15 @@ public class GameWorld {
         objects.add(object);
     }
 
+    public void removeObject(GameObject object) {
+        if (!objects.contains(object)) return;
+        objects.remove(object);
+    }
+
+    public void clearWorld() {
+        objects.clear();
+    }
+
     public List<GameObject> getObjects() {
         return objects;
     }

--- a/src/main/java/io/github/moonslanding/tlm/engine/SpritedGameObject.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/SpritedGameObject.java
@@ -35,6 +35,19 @@ public class SpritedGameObject extends GameObject implements IRenderable {
         }
     }
 
+    @Override
+    public void render(WrappedGraphic graphics, int x, int y) {
+        Graphics graphic = graphics.getGraphic();
+        if (sprite != null) {
+            BufferedImage img = createGraphic(sprite.getTexture(), graphics);
+
+            graphic.drawImage(img,
+                    x - (img.getWidth() / 2),
+                    y - (img.getHeight() / 2),
+                    null);
+        }
+    }
+
     public void setTint(Color tint) {
         this.tint = tint;
     }

--- a/src/main/java/io/github/moonslanding/tlm/engine/SpritedGameObject.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/SpritedGameObject.java
@@ -25,9 +25,13 @@ public class SpritedGameObject extends GameObject implements IRenderable {
     public void render(WrappedGraphic graphics) {
         Graphics graphic = graphics.getGraphic();
         if (sprite != null) {
-
             BufferedImage img = createGraphic(sprite.getTexture(), graphics);
-            graphic.drawImage(img, getX(), getY(), null);
+
+            // Because the image is influenced by size, we cannot just use getX() and getY().
+            graphic.drawImage(img,
+                    getX() - (img.getWidth() / 2),
+                    getY() - (img.getHeight() / 2),
+                    null);
         }
     }
 

--- a/src/main/java/io/github/moonslanding/tlm/engine/interfaces/IRenderable.java
+++ b/src/main/java/io/github/moonslanding/tlm/engine/interfaces/IRenderable.java
@@ -8,4 +8,6 @@ public interface IRenderable {
 
     void render(WrappedGraphic graphics);
 
+    void render(WrappedGraphic graphics, int x, int y);
+
 }


### PR DESCRIPTION
- [x] Switch from Canvas AWT to JPanel Swing
- [x] A new GameView class that can follow a PivotObject
  - [x] It should be follow and place the object in center.
  - [x] Render only the objects in the GameView FoV.
  - [x] When the pivot object goes into a wall or corner, the pivot object is leased into the wall/corner until they came back to the specific threshold.

Breaking because this PR changes how the GameView draws, I had to separate the extract the IRenderable painting into new method.

Additionally, I decided that we will actually move from AWT to Swing. (Canvas => JPanel)